### PR TITLE
Add local server and session duration option

### DIFF
--- a/Hemi-Lab_Ultra++.html
+++ b/Hemi-Lab_Ultra++.html
@@ -456,6 +456,10 @@
                         <input type="range" class="slider" id="phaseShift" min="0" max="360" value="0">
                     </div>
                     <div class="control-group">
+                        <label>Session Duration (min): <span id="durationValue">15</span></label>
+                        <input type="range" class="slider" id="sessionDuration" min="1" max="60" value="15">
+                    </div>
+                    <div class="control-group">
                         <label>
                             <input type="checkbox" id="isochronicMode"> Isochronic Pulse Layer
                         </label>
@@ -551,6 +555,7 @@
                 this.sessionTimer = null;
                 this.currentFocusLevel = null;
                 this.breathCycle = null;
+                this.targetDuration = 15 * 60;
                 
                 this.focusPresets = {
                     10: { baseFreq: 100, beatFreq: 7.5, description: "Body asleep, mind awake" },
@@ -608,6 +613,10 @@
                     if (this.isPlaying) this.updatePhaseShift();
                 });
 
+                document.getElementById('sessionDuration').addEventListener('input', (e) => {
+                    document.getElementById('durationValue').textContent = e.target.value;
+                    this.targetDuration = parseInt(e.target.value) * 60;
+                });
                 // Session controls
                 document.getElementById('startBtn').addEventListener('click', () => this.startSession());
                 document.getElementById('stopBtn').addEventListener('click', () => this.stopSession());
@@ -651,6 +660,7 @@
                     const beatFreq = parseFloat(document.getElementById('beatFreq').value);
                     const volume = parseFloat(document.getElementById('volume').value) / 100;
                     const phaseShift = parseFloat(document.getElementById('phaseShift').value);
+                    this.targetDuration = parseInt(document.getElementById('sessionDuration').value) * 60;
 
                     const delaySeconds = (phaseShift / 360) / baseFreq;
 
@@ -789,6 +799,9 @@
                     const seconds = elapsed % 60;
                     document.getElementById('sessionTimer').textContent = 
                         `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+                    if (this.targetDuration && elapsed >= this.targetDuration) {
+                        this.stopSession();
+                    }
                 }, 1000);
             }
 

--- a/README.md
+++ b/README.md
@@ -24,3 +24,6 @@ For best results:
 - Journal your experiences after each session
 
 The deeper states (Focus 15, 21, 23+) may produce profound experiences. Trust the process and document everything.
+
+## Local Development Server
+Run `node server.js` and open [http://localhost:3000](http://localhost:3000) to use the app locally.

--- a/server.js
+++ b/server.js
@@ -1,0 +1,38 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = process.env.PORT || 3000;
+const root = path.join(__dirname);
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.gif': 'image/gif'
+};
+
+const server = http.createServer((req, res) => {
+  const filePath = req.url === '/' ? '/Hemi-Lab_Ultra++.html' : req.url;
+  const fullPath = path.join(root, filePath);
+
+  fs.readFile(fullPath, (err, data) => {
+    if (err) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('404 Not Found');
+      return;
+    }
+
+    const ext = path.extname(fullPath);
+    const type = mimeTypes[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': type });
+    res.end(data);
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Hemi-Lab server running at http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- add small development server using Node's http module
- enable session duration selection and auto-stop logic
- document how to run the local server

## Testing
- `node server.js` *(fails: Cannot find module 'http'? Should succeed)*

------
https://chatgpt.com/codex/tasks/task_e_6863605bb6148324baba194a7b971d5a